### PR TITLE
Added test and ol_unjar_dsize.

### DIFF
--- a/include/oleg.h
+++ b/include/oleg.h
@@ -151,12 +151,21 @@ int ol_close(ol_database *database);
 int ol_close_save(ol_database *database);
 
 /* xXx FUNCTION=ol_unjar xXx
- * xXx DESCRIPTION=Unjar a value from the mayo. xXx
+ * xXx DESCRIPTION=Unjar a value from the mayo. Calls ol_unjar_ks with a dsize of null. xXx
  * xXx RETURNS=A pointer to an ol_val object, or NULL if the object was not found. xXx
  * xXx *db=Database to retrieve value from. xXx
  * xXx *key=The key to use. xXx
  */
 ol_val ol_unjar(ol_database *db, const char *key);
+
+/* xXx FUNCTION=ol_unjar_ks xXx
+ * xXx DESCRIPTION=Unjar a value from the mayo. Makes ksize a reference to the size of the data returned. xXx
+ * xXx RETURNS=A pointer to an ol_val object, or NULL if the object was not found. xXx
+ * xXx *db=Database to retrieve value from. xXx
+ * xXx *key=The key to use. xXx
+ * xXx *dsize=The key to use. xXx
+ */
+ol_val ol_unjar_ds(ol_database *db, const char *key, size_t *dsize);
 
 /* xXx FUNCTION=ol_jar xXx
  * xXx DESCRIPTION=Put a value into the mayo. It's easy to piss in a bucket, it's not easy to piss in 19 jars. Uses default content type. xXx

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -211,12 +211,20 @@ error:
 }
 
 ol_val ol_unjar(ol_database *db, const char *key) {
+    return ol_unjar_ds(db, key, NULL);
+}
+
+ol_val ol_unjar_ds(ol_database *db, const char *key, size_t *dsize) {
     uint32_t hash;
     MurmurHash3_x86_32(key, strlen(key), DEVILS_SEED, &hash);
     ol_bucket *bucket = _ol_get_bucket(db, hash, key);
 
-    if (bucket != NULL)
+
+    if (bucket != NULL) {
+        if (dsize != NULL)
+            memcpy(dsize, &bucket->data_size, sizeof(size_t));
         return bucket->data_ptr;
+    }
 
     return NULL;
 }

--- a/src/port_driver.c
+++ b/src/port_driver.c
@@ -139,13 +139,14 @@ static void oleg_output(ErlDrvData data, char *cmd, ErlDrvSizeT clen) {
         ei_x_free(&to_send);
     } else if (fn == 2) {
         /* ol_unjar */
-        unsigned char *data = ol_unjar(d->db, obj->key);
+        size_t val_size;
+        unsigned char *data = ol_unjar_ds(d->db, obj->key, &val_size);
         ei_x_buff to_send;
         ei_x_new_with_version(&to_send);
         if (data != NULL) {
             ei_x_encode_tuple_header(&to_send, 2);
             ei_x_encode_atom(&to_send, "ok");
-            ei_x_encode_binary(&to_send, data, strlen((char*)data));
+            ei_x_encode_binary(&to_send, data, val_size);
         } else {
             ei_x_encode_atom(&to_send, "not_found");
         }

--- a/src/test.c
+++ b/src/test.c
@@ -92,6 +92,46 @@ int test_jar() {
     return 0;
 }
 
+int test_unjar_ds() {
+    ol_database *db = ol_open(DB_PATH, DB_NAME, OL_SLAUGHTER_DIR);
+    ol_log_msg(LOG_INFO, "Opened DB: %p.", db);
+
+    char key[] = "FANCY KEY IS YO MAMA";
+    unsigned char val[] = "invariable variables invariably trip up programmers";
+    size_t val_len = strlen((char*)val);
+    int inserted = ol_jar(db, key, val, val_len);
+
+    if (inserted > 0) {
+        ol_log_msg(LOG_ERR, "Could not insert. Error code: %i\n", inserted);
+        ol_close(db);
+        return 1;
+    }
+
+    size_t to_test;
+    ol_val item = ol_unjar_ds(db, key, &to_test);
+    ol_log_msg(LOG_INFO, "Retrieved value.");
+    if (item == NULL) {
+        ol_log_msg(LOG_ERR, "Could not find key: %s\n", key);
+        ol_close(db);
+        return 2;
+    }
+
+    if (memcmp(item, val, strlen((char*)val)) != 0) {
+        ol_log_msg(LOG_ERR, "Returned value was not the same.\n");
+        ol_close(db);
+        return 3;
+    }
+
+    if (to_test != val_len) {
+        ol_log_msg(LOG_ERR, "Sizes were not the same. %p (to_test) vs. %p (val_len)\n", to_test, val_len);
+        ol_close(db);
+        return 4;
+    }
+
+
+    ol_close(db);
+    return 0;
+}
 int test_unjar() {
     /* TODO: This test should actually make sure all of the data is consistent */
     ol_database *db = ol_open(DB_PATH, DB_NAME, OL_SLAUGHTER_DIR);
@@ -381,6 +421,7 @@ void run_tests(int results[2]) {
     ol_run_test(test_bucket_max);
     ol_run_test(test_jar);
     ol_run_test(test_unjar);
+    ol_run_test(test_unjar_ds);
     ol_run_test(test_scoop);
     ol_run_test(test_update);
     ol_run_test(test_ct);


### PR DESCRIPTION
This allows people to optionally retrieve the length of the value they
want (we store it when we ol_jar it) without breaking the existing API.
