### PR TITLE
Fixed hardcoded bash interpreter path not working in some configurations

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export ERL_MAX_PORTS=4096
 RUN_DIR=/run/olegdb

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export LD_LIBRARY_PATH=./build/lib:$LD_LIBRARY_PATH
 ./build/bin/oleg_test test


### PR DESCRIPTION
This fixes it on FreeBSD at least.

Also, if you want to be picky, specify it's GNU Make, the makefile doesn't work on BSD's Make
