### PR TITLE
Removed bash requirement

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 export ERL_MAX_PORTS=4096
 RUN_DIR=/run/olegdb

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 export LD_LIBRARY_PATH=./build/lib:$LD_LIBRARY_PATH
 ./build/bin/oleg_test test


### PR DESCRIPTION
On some operating systems Bash is not present by default and since it's not needed for the .sh files anyway (they don't use any bash-specific hack afaik), why keep it?
/bin/sh is basically guaranteed to be always present and points to a sh-compatible shell (bash, ksh, ash etc.).
