### PR TITLE
Change tempnam(2) to mkdtemp(1)

### DIFF
--- a/c_src/test.c
+++ b/c_src/test.c
@@ -16,8 +16,8 @@
  * in a million places when we modify it.
  */
 ol_database *_test_db_open(const ol_feature_flags features) {
-    char DB_PATH[] = "/tmp/oleg-XXXXXX";
-    mkdtemp(DB_PATH);
+    char template[] = "/tmp/oleg-XXXXXX";
+    char *DB_PATH = mkdtemp(template);
     if (DB_PATH == NULL) {
         ol_log_msg(LOG_ERR, "Can't create unique directory");
         return NULL;


### PR DESCRIPTION
This gets rid of the warning about security (and apparently it's the Correct™ way of doing it).

Compiles and runs fine on Linux (Solaris doesn't compile because the fixes are in the Transaction branch, FreeBSD hangs on tests even with normal master)
