### PR TITLE
Smaller keys

### DIFF
--- a/include/oleg.h
+++ b/include/oleg.h
@@ -65,7 +65,7 @@ typedef char **ol_key_array;
 * xXx tx_id=If this record is a part of a transaction, then this will be a non-negative integer.
 */
 typedef struct ol_bucket {
-    char                key[KEY_SIZE]; /* The key used to reference the data */
+    char                *key;
     size_t              klen;
     size_t              data_offset;
     size_t              data_size;

--- a/include/tree.h
+++ b/include/tree.h
@@ -9,7 +9,7 @@ typedef struct ol_splay_tree_node {
     struct  ol_splay_tree_node *right;
     struct  ol_splay_tree_node *parent;
 
-    char    key[KEY_SIZE];
+    char    *key;
     size_t  klen;
     const void *ref_obj;
 } ol_splay_tree_node;

--- a/src/aol.c
+++ b/src/aol.c
@@ -82,7 +82,7 @@ int ol_aol_write_cmd(ol_database *db, const char *cmd, ol_bucket *bct) {
         /* I'LL RIGOR YER MORTIS */
         const size_t write_buf_size =
             strlen(":") + uintlen(strlen(cmd)) + strlen(":") + strlen(cmd) +
-            strlen(":") + uintlen(bct->klen) + strlen(":") + strlen(bct->key) +
+            strlen(":") + uintlen(bct->klen) + strlen(":") + bct->klen +
             strlen(":1: ") +
             strlen(":") + uintlen(uintlen(bct->original_size)) + strlen(":") + uintlen(bct->original_size) +
             strlen(":") + uintlen(uintlen(bct->data_size)) + strlen(":") + uintlen(bct->data_size) +

--- a/src/test.c
+++ b/src/test.c
@@ -986,8 +986,8 @@ int test_compaction(const ol_feature_flags features) {
         char key[64] = "crazy hash";
         char buf[20] = {0};
         sprintf(buf, "%i", i);
-        strncat(key, buf, 30);
-        check(ol_scoop(db, key, strnlen(key, 64)) == 0, "Could not delete record %s.", key);
+        strncat(key, buf, sizeof(key));
+        check(ol_scoop(db, key, strnlen(key, sizeof(key))) == 0, "Could not delete record %s.", key);
     }
 
     struct tm *now;

--- a/src/test.c
+++ b/src/test.c
@@ -986,7 +986,7 @@ int test_compaction(const ol_feature_flags features) {
         char key[64] = "crazy hash";
         char buf[20] = {0};
         sprintf(buf, "%i", i);
-        strncat(key, buf, sizeof(key));
+        strncat(key, buf, 30);
         check(ol_scoop(db, key, strnlen(key, sizeof(key))) == 0, "Could not delete record %s.", key);
     }
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -455,8 +455,15 @@ int olt_spoil(ol_transaction *tx, const char *key, size_t klen, struct tm *expir
              */
             uint32_t hash;
             MurmurHash3_x86_32(_key, _klen, DEVILS_SEED, &hash);
-            ol_bucket *copied = calloc(1, sizeof(ol_bucket));
+            ol_bucket *copied = malloc(sizeof(ol_bucket));
             check_mem(copied);
+
+            memcpy(copied, bucket, sizeof(ol_bucket));
+
+            copied->key = malloc(_klen + 1);
+            check_mem(copied->key);
+            copied->key[_klen] = '\0';
+            memcpy(copied->key, bucket->key, _klen);
 
             _ol_set_bucket_no_incr(operating_db, copied, hash);
         }

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -241,6 +241,9 @@ int olt_jar(ol_transaction *tx, const char *key, size_t klen, const unsigned cha
         return 1;
 
     /* copy _key into new bucket */
+    new_bucket->key = malloc(_klen + 1);
+    check_mem(new_bucket->key);
+    new_bucket->key[_klen] = '\0';
     if (strncpy(new_bucket->key, _key, _klen) != new_bucket->key) {
         free(new_bucket);
         return 2;

--- a/src/tree.c
+++ b/src/tree.c
@@ -133,7 +133,10 @@ ol_splay_tree_node *ols_insert(ol_splay_tree *tree, const char *key, const size_
     current_node->right = NULL;
     current_node->parent = NULL;
     current_node->klen = 0;
-    memset(current_node->key, '\0', KEY_SIZE);
+    current_node->key = malloc(klen + 1);
+    current_node->key[klen] = '\0';
+    check_mem(current_node->key);
+
     if (strncpy(current_node->key, key, klen) != current_node->key) {
         free(current_node);
         return NULL;
@@ -247,6 +250,7 @@ static inline void _ols_free_node(ol_splay_tree_node *node) {
         if (cur_node->right != NULL) {
             spush(&stack, (void *)cur_node->right);
         }
+        free(cur_node->key);
         free(cur_node);
     }
     debug("Tree cleared. Iterations: %i", iters);

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,8 +38,11 @@ int _has_bucket_expired(const ol_bucket *bucket) {
     }
 
     /* For some reason you can't compare 0 to a time_t. */
-    if (current < made)
-        return 0;
+    if (current < made) {
+        {   /* Double-wrap the braces in case the first ones are optimized out. */
+            return 0;
+        }
+    }
     return 1;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,9 +38,8 @@ int _has_bucket_expired(const ol_bucket *bucket) {
     }
 
     /* For some reason you can't compare 0 to a time_t. */
-    if (current < made) {
+    if (current < made)
         return 0;
-    }
     return 1;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -46,6 +46,7 @@ int _has_bucket_expired(const ol_bucket *bucket) {
 
 void _ol_free_bucket(ol_bucket **ptr) {
     free((*ptr)->expiration);
+    free((*ptr)->key);
     free((*ptr));
     *ptr = NULL;
 }
@@ -202,7 +203,7 @@ int _ol_get_value_from_bucket(const ol_database *db, const ol_bucket *bucket,
         processed = LZ4_decompress_fast((char *)data_ptr,
                                         (char *)*data,
                                         bucket->original_size);
-        check(processed == bucket->data_size, "Could not decompress data.");
+        check(processed == bucket->data_size, "Could not decompress data. Key: %s", bucket->key);
     } else {
         /* We know data isn't NULL by this point. */
         unsigned char *ret = memcpy(*data, data_ptr, bucket->original_size);


### PR DESCRIPTION
Allocates keys on the heap instead of the stack. Also fixes a random `olt_spoil` bug that I found. This might fix the random segfaults that happen when running against `torture.py`, I'll test later.

Ping @kyleterry @dequis I guess. Do we still do code review?