### PR TITLE
174 error codes

### DIFF
--- a/include/defs.h
+++ b/include/defs.h
@@ -51,3 +51,12 @@
  */
 #define AOL_FILENAME "aol"
 
+/* xXx DEFINE=OL_SUCCESS xXx
+ * xXx DESCRIPTION=Used to indicate an operation went according to plan.
+ */
+#define OL_SUCCESS 0
+
+/* xXx DEFINE=OL_FAILURE xXx
+ * xXx DESCRIPTION=Used to indicate an operation failed.
+ */
+#define OL_FAILURE 1

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -38,12 +38,11 @@ typedef enum {
 /* xXx ENUM=ol_error xXx
 * xXx DESCRIPTION=Error codes. xXx
 * xXx OL_NO_ERROR=Everything is fine. xXx
-* xXx OL_GENERIC_ERROR=Uknown error of some kind. xXx
+* xXx OL_GENERIC_ERROR=Uknown error of some kind. Like, whatever. xXx
 */
 typedef enum {
     OL_E_NO_ERROR,
-    OL_E_GENERIC_ERROR,
-    OL_E_COULD_NOT_FREE
+    OL_E_GENERIC_ERROR
 } ol_error;
 
 /* xXx ENUM=ol_state_flags xXx
@@ -169,7 +168,7 @@ int ol_close_fast(ol_database *database);
 
 /* xXx FUNCTION=ol_unjar xXx
  * xXx DESCRIPTION=This function retrieves a value from the database. <strong>data must be freed after calling this function!</strong> It also writes the size of the data to <code>dsize</code>. Pass dsize as NULL if you don't care. xXx
- * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE on failure or if the key was not found.
+ * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE on failure or if the key was not found. xXx
  * xXx *db=Database to retrieve value from. xXx
  * xXx *key=The key to use. xXx
  * xXx klen=The length of the key to use. xXx
@@ -180,7 +179,7 @@ int ol_unjar(ol_database *db, const char *key, size_t klen, unsigned char **data
 
 /* xXx FUNCTION=ol_jar xXx
  * xXx DESCRIPTION=This is OlegDB's canonical 'set' function. Put a value into the mayo (the database). It's easy to piss in a bucket, it's not easy to piss in 19 jars. xXx
- * xXx RETURNS=0 on success. xXx
+ * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE on an obtuse set of different failure modes. xXx
  * xXx *db=Database to set the value to. xXx
  * xXx *key=The key to use. xXx
  * xXx klen=The length of the key. xXx
@@ -200,7 +199,7 @@ struct tm *ol_sniff(ol_database *db, const char *key, size_t klen);
 
 /* xXx FUNCTION=ol_scoop xXx
  * xXx DESCRIPTION=Removes an object from the database. Get that crap out of the mayo jar. xXx
- * xXx RETURNS=0 on success, and 1 or 2 if the object could not be deleted. xXx
+ * xXx RETURNS=OL_SUCCESS when it succeeds, OL_FAILURE when it doesn't. xXx
  * xXx *db=Database to remove the value from. xXx
  * xXx *key=The key to use. xXx
  * xXx klen=The length of the key. xXx

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -35,6 +35,16 @@ typedef enum {
     OL_F_DISABLE_TX                 = 1 << 4
 } ol_feature_flags;
 
+/* xXx ENUM=ol_error xXx
+* xXx DESCRIPTION=Error codes. xXx
+* xXx OL_NO_ERROR=Everything is fine. xXx
+* xXx OL_GENERIC_ERROR=Uknown error of some kind. xXx
+*/
+typedef enum {
+    OL_NO_ERROR,
+    OL_GENERIC_ERROR,
+} ol_feature_flags;
+
 /* xXx ENUM=ol_state_flags xXx
 * xXx DESCRIPTION=State flags tell the database what it should be doing. xXx
 * xXx OL_S_STARTUP=Startup state. The DB is starting, duh. xXx
@@ -84,6 +94,7 @@ typedef struct ol_bucket {
 typedef struct ol_meta {
     time_t      created;
     int         key_collisions;
+    ol_error    last_error;
 } ol_meta;
 
 /* xXx STRUCT=ol_database xXx
@@ -288,6 +299,13 @@ int ol_cas(ol_database *db, const char *key, const size_t klen,
  * xXx num_keys=The number of keys in <code>*keys</code>. xXx
  */
 struct vector *ol_bulk_unjar(ol_database *db, const ol_key_array keys, const size_t num_keys);
+
+/* xXx FUNCTION=ol_last_error xXx
+ * xXx DESCRIPTION=Turns error codes on the database object into human readable strings. xXx
+ * xXx RETURNS=Returns a human readable string representing the last error that happened to <code>*db.</code> xXx
+ * xXx *db=The database to check. xXx
+ */
+const char *ol_last_error(const ol_database *db);
 
 #ifdef __cplusplus
 }

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -232,7 +232,7 @@ unsigned int ol_ht_bucket_max(size_t ht_size);
 
 /* xXx FUNCTION=ol_prefix_match xXx
  * xXx DESCRIPTION=Returns values of keys that match a given prefix. xXx
- * xXx RETURNS=-1 on failure and a positive integer representing the number of matched prefices in the database. xXx
+ * xXx RETURNS=-1 on failure, otherwise a positive integer representing the number of matched prefices in the database. xXx
  * xXx *db=Database to retrieve values from. xXx
  * xXx *prefix=The prefix to attempt matches on. xXx
  * xXx plen=The length of the prefix. xXx
@@ -242,7 +242,7 @@ int ol_prefix_match(ol_database *db, const char *prefix, size_t plen, ol_key_arr
 
 /* xXx FUNCTION=ol_key_dump xXx
  * xXx DESCRIPTION=Like ol_prefix_match, except that it takes no prefix and just dumps the entire tree. xXx
- * xXx RETURNS=-1 on failure and a positive integer representing the number of keys in the database. xXx
+ * xXx RETURNS=-1 on failure, otherwise a positive integer representing the number of keys in the database on success. xXx
  * xXx *db=Database to retrieve values from. xXx
  * xXx *data=A pointer to an <code>ol_key_array</code> object where the list of keys will be stored. <strong>Both the list and it's items must be freed after use.</strong> xXx
  */
@@ -250,7 +250,7 @@ int ol_key_dump(ol_database *db, ol_key_array *data);
 
 /* xXx FUNCTION=ol_exists xXx
  * xXx DESCRIPTION=Returns whether the given key exists on the database xXx
- * xXx RETURNS=0 if the key exists, 1 otherwise. xXx
+ * xXx RETURNS=OL_SUCCESS if the key exists, OL_FAILURE otherwise. xXx
  * xXx *db=Database the key should be in. xXx
  * xXx *key=The key to check. xXx
  * xXx klen=The length of the key. xXx
@@ -271,14 +271,14 @@ ol_bucket *ol_get_bucket(const ol_database *db, const char *key, const size_t kl
 
 /* xXx FUNCTION=ol_squish xXx
  * xXx DESCRIPTION=Compacts both the aol file (if enabled) and the values file. This is a blocking operation. xXx
- * xXx RETURNS=0 if successful, 1 if otherwise. xXx
+ * xXx RETURNS=OL_SUCCESS if successful, OL_FAILURE if otherwise. xXx
  * xXx *db=The database to compact. xXx
  */
 int ol_squish(ol_database *db);
 
 /* xXx FUNCTION=ol_cas xXx
  * xXx DESCRIPTION=ol_jar operation that atomically compares-and-swaps old data for new data. xXx
- * xXx RETURNS=0 on success. xXx
+ * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE otherwise. xXx
  * xXx *db=The database to operate on. xXx
  * xXx *key=The key to check. xXx
  * xXx klen=The length of the key. xXx

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -41,8 +41,8 @@ typedef enum {
 * xXx OL_GENERIC_ERROR=Unkown error of some kind. Like, whatever. xXx
 */
 typedef enum {
-    OL_E_NO_ERROR,
-    OL_E_GENERIC_ERROR
+    OL_E_NO_ERROR       = 0,
+    OL_E_GENERIC_ERROR  = 1
 } ol_error;
 
 /* xXx ENUM=ol_state_flags xXx

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -41,9 +41,10 @@ typedef enum {
 * xXx OL_GENERIC_ERROR=Uknown error of some kind. xXx
 */
 typedef enum {
-    OL_NO_ERROR,
-    OL_GENERIC_ERROR,
-} ol_feature_flags;
+    OL_E_NO_ERROR,
+    OL_E_GENERIC_ERROR,
+    OL_E_COULD_NOT_FREE
+} ol_error;
 
 /* xXx ENUM=ol_state_flags xXx
 * xXx DESCRIPTION=State flags tell the database what it should be doing. xXx
@@ -154,21 +155,21 @@ ol_database *ol_open(const char *path, const char *name, int features);
 
 /* xXx FUNCTION=ol_close xXx
  * xXx DESCRIPTION=Closes a database cleanly and frees memory. xXx
- * xXx RETURNS=0 on success, 1 if not everything could be freed. xXx
+ * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE if not everything could be freed. xXx
  * xXx *database=The database to close. xXx
  */
 int ol_close(ol_database *database);
 
 /* xXx FUNCTION=ol_close_fast xXx
  * xXx DESCRIPTION=Closes a database without syncing the AOL or Values file. Intended to be used for transaction that did nothing. xXx
- * xXx RETURNS=0 on success, 1 if not everything could be freed. xXx
+ * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE if not everything could be freed. xXx
  * xXx *database=The database to close. xXx
  */
 int ol_close_fast(ol_database *database);
 
 /* xXx FUNCTION=ol_unjar xXx
  * xXx DESCRIPTION=This function retrieves a value from the database. <strong>data must be freed after calling this function!</strong> It also writes the size of the data to <code>dsize</code>. Pass dsize as NULL if you don't care. xXx
- * xXx RETURNS=0 on success, 1 on failure or if the key was not found.
+ * xXx RETURNS=OL_SUCCESS on success, OL_FAILURE on failure or if the key was not found.
  * xXx *db=Database to retrieve value from. xXx
  * xXx *key=The key to use. xXx
  * xXx klen=The length of the key to use. xXx

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -215,7 +215,7 @@ int ol_uptime(ol_database *db);
 
 /* xXx FUNCTION=ol_spoil xXx
  * xXx DESCRIPTION=Sets the expiration value of a key. Will fail if no <a href="#ol_bucket">ol_bucket</a> under the chosen key exists. xXx
- * xXx RETURNS=0 upon success, 1 if otherwise. xXx
+ * xXx RETURNS=OL_SUCCESS upon success, OL_FAILURE if otherwise. xXx
  * xXx *db=Database to set the value to. xXx
  * xXx *key=The key to use. xXx
  * xXx klen=The length of the key. xXx

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -92,9 +92,9 @@ typedef struct ol_bucket {
 * xXx key_collisions=The number of keys that have collided over the lifetime of this database. xXx
 */
 typedef struct ol_meta {
-    time_t      created;
-    int         key_collisions;
-    ol_error    last_error;
+    time_t     created;
+    int        key_collisions;
+    uint16_t   last_error;
 } ol_meta;
 
 /* xXx STRUCT=ol_database xXx

--- a/include/oleg.h
+++ b/include/oleg.h
@@ -38,7 +38,7 @@ typedef enum {
 /* xXx ENUM=ol_error xXx
 * xXx DESCRIPTION=Error codes. xXx
 * xXx OL_NO_ERROR=Everything is fine. xXx
-* xXx OL_GENERIC_ERROR=Uknown error of some kind. Like, whatever. xXx
+* xXx OL_GENERIC_ERROR=Unkown error of some kind. Like, whatever. xXx
 */
 typedef enum {
     OL_E_NO_ERROR,

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -173,10 +173,11 @@ static inline int _ol_close_common(ol_database *db) {
         db->tree = NULL;
     }
 
-    return 0;
+    return OL_SUCCESS;
 
 error:
-    return 1;
+    db->meta->last_error = OL_E_COULD_NOT_FREE;
+    return OL_FAILURE;
 }
 
 static inline void _ol_close_final(ol_database *db) {
@@ -265,21 +266,23 @@ int ol_unjar(ol_database *db, const char *key, size_t klen, unsigned char **data
     }
 
     ol_transaction *tx = olt_begin(db);
-    int unjar_ret = 10;
+    /* TODO: Set error code here */
     check(tx != NULL, "Could not begin transaction.");
 
-    unjar_ret = olt_unjar(tx, key, klen, data, dsize);
-    check(unjar_ret != 2, "Could not unjar.");
+    /* TODO: Set error code here */
+    int unjar_ret = olt_unjar(tx, key, klen, data, dsize);
+    check(unjar_ret == OL_SUCCESS, "Could not unjar.");
 
-    check(olt_commit(tx) == 0, "Could not commit transaction.");
+    /* TODO: Set error code here */
+    check(olt_commit(tx) == OL_SUCCESS, "Could not commit transaction.");
 
-    return unjar_ret;
+    return OL_SUCCESS;
 
 error:
-    if (tx != NULL && unjar_ret != 10)
+    if (tx != NULL && unjar_ret != OL_SUCCESS)
         olt_abort(tx);
 
-    return unjar_ret;
+    return OL_FAILURE;
 }
 
 int ol_jar(ol_database *db, const char *key, size_t klen,

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -176,7 +176,6 @@ static inline int _ol_close_common(ol_database *db) {
     return OL_SUCCESS;
 
 error:
-    db->meta->last_error = OL_E_COULD_NOT_FREE;
     return OL_FAILURE;
 }
 
@@ -266,14 +265,12 @@ int ol_unjar(ol_database *db, const char *key, size_t klen, unsigned char **data
     }
 
     ol_transaction *tx = olt_begin(db);
-    /* TODO: Set error code here */
+    int unjar_ret = OL_SUCCESS;
     check(tx != NULL, "Could not begin transaction.");
 
-    /* TODO: Set error code here */
-    int unjar_ret = olt_unjar(tx, key, klen, data, dsize);
+    unjar_ret = olt_unjar(tx, key, klen, data, dsize);
     check(unjar_ret == OL_SUCCESS, "Could not unjar.");
 
-    /* TODO: Set error code here */
     check(olt_commit(tx) == OL_SUCCESS, "Could not commit transaction.");
 
     return OL_SUCCESS;
@@ -301,21 +298,21 @@ int ol_jar(ol_database *db, const char *key, size_t klen,
     }
 
     ol_transaction *tx = olt_begin(db);
-    int jar_ret = 10;
+    int jar_ret = OL_SUCCESS;
     check(tx != NULL, "Could not begin implicit transaction.");
 
     jar_ret = olt_jar(tx, key, klen, value, vsize);
-    check(jar_ret == 0, "Could not jar value. Aborting.");
+    check(jar_ret == OL_SUCCESS, "Could not jar value. Aborting.");
 
-    check(olt_commit(tx) == 0, "Could not commit transaction.");
+    check(olt_commit(tx) == OL_SUCCESS, "Could not commit transaction.");
 
-    return jar_ret;
+    return OL_SUCCESS;
 
 error:
-    if (tx != NULL && jar_ret != 10)
+    if (tx != NULL && jar_ret != OL_SUCCESS)
         olt_abort(tx);
 
-    return jar_ret;
+    return OL_FAILURE;
 }
 
 int ol_spoil(ol_database *db, const char *key, size_t klen, struct tm *expiration_date) {
@@ -363,21 +360,21 @@ int ol_scoop(ol_database *db, const char *key, size_t klen) {
     }
 
     ol_transaction *tx = olt_begin(db);
-    int scoop_ret = 10;
+    int scoop_ret = OL_SUCCESS;
     check(tx != NULL, "Could not begin implicit transaction.");
 
     scoop_ret = olt_scoop(tx, key, klen);
-    check(scoop_ret == 0, "Could not scoop value. Aborting.");
+    check(scoop_ret == OL_SUCCESS, "Could not scoop value. Aborting.");
 
-    check(olt_commit(tx) == 0, "Could not commit transaction.");
+    check(olt_commit(tx) == OL_SUCCESS, "Could not commit transaction.");
 
-    return scoop_ret;
+    return OL_SUCCESS;
 
 error:
     if (tx != NULL && scoop_ret != 10)
         olt_abort(tx);
 
-    return scoop_ret;
+    return OL_FAILURE;
 }
 
 int ol_cas(ol_database *db, const char *key, const size_t klen,

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -66,6 +66,7 @@ ol_database *ol_open(const char *path, const char *name, int features){
     new_db->meta = malloc(sizeof(ol_meta));
     new_db->meta->created = created;
     new_db->meta->key_collisions = 0;
+    new_db->meta->last_error = 0;
     new_db->rcrd_cnt = 0;
     new_db->val_size = 0;
     new_db->cur_transactions = NULL;
@@ -557,4 +558,13 @@ int ol_uptime(ol_database *db) {
     time(&now);
     diff = difftime(now, db->meta->created);
     return diff;
+}
+
+const char *ol_last_error(const ol_database *db) {
+    static const char *human_readable[] = {
+        "No error.",
+        "Generic error."
+    };
+
+    return human_readable[db->meta->last_error];
 }

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -565,6 +565,10 @@ const char *ol_last_error(const ol_database *db) {
         "No error.",
         "Generic error."
     };
+    const size_t err_codes_siz = sizeof(human_readable)/sizeof(human_readable[0]);
+
+    if (db->meta->last_error > err_codes_siz || db->meta->last_error < 0)
+        return NULL;
 
     return human_readable[db->meta->last_error];
 }

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -329,22 +329,23 @@ int ol_spoil(ol_database *db, const char *key, size_t klen, struct tm *expiratio
 
     debug("Beginning ol_spoil.");
     ol_transaction *tx = olt_begin(db);
-    int spoil_ret = 10;
+    int spoil_ret = OL_SUCCESS;
     check(tx != NULL, "Could not begin implicit transaction.");
 
     spoil_ret = olt_spoil(tx, key, klen, expiration_date);
-    check(spoil_ret == 0, "Could not spoil value. Aborting.");
-    check(olt_commit(tx) == 0, "Could not commit transaction.");
+    check(spoil_ret == OL_SUCCESS, "Could not spoil value. Aborting.");
+
+    check(olt_commit(tx) == OL_SUCCESS, "Could not commit transaction.");
     debug("End of ol_spoil.");
 
-    return spoil_ret;
+    return OL_SUCCESS;
 
 error:
     debug("Error in ol_spoil.");
-    if (tx != NULL && spoil_ret != 10)
+    if (tx != NULL && spoil_ret != OL_SUCCESS)
         olt_abort(tx);
 
-    return spoil_ret;
+    return OL_FAILURE;
 }
 
 int ol_scoop(ol_database *db, const char *key, size_t klen) {

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -567,7 +567,7 @@ const char *ol_last_error(const ol_database *db) {
     };
     const size_t err_codes_siz = sizeof(human_readable)/sizeof(human_readable[0]);
 
-    if (db->meta->last_error > err_codes_siz || db->meta->last_error < 0)
+    if (db->meta->last_error > err_codes_siz)
         return NULL;
 
     return human_readable[db->meta->last_error];

--- a/src/oleg.c
+++ b/src/oleg.c
@@ -389,14 +389,14 @@ int ol_cas(ol_database *db, const char *key, const size_t klen,
     size_t _klen = 0;
 
     ol_bucket *bucket = ol_get_bucket(db, key, klen, &_key, &_klen);
-    check_warn(_klen > 0, "Key length of zero not allowed.");
+    check(_klen > 0, "Key length of zero not allowed.");
 
     if (bucket == NULL)
-        return 1;
+        return OL_FAILURE;
 
     /* Quick fail if the two sizes don't match */
     if (bucket->original_size != ovsize)
-        return 1;
+        return OL_FAILURE;
 
     /* ATOMIC, GOOOO! */
     const unsigned char *data_ptr = db->values + bucket->data_offset;
@@ -417,10 +417,10 @@ int ol_cas(ol_database *db, const char *key, const size_t klen,
             return ol_jar(db, key, klen, value, vsize);
     }
 
-    return 1;
+    return OL_FAILURE;
 
 error:
-    return 1;
+    return OL_FAILURE;
 }
 
 int ol_squish(ol_database *db) {
@@ -495,10 +495,10 @@ int ol_squish(ol_database *db) {
         db->aolfd = fopen(db->aol_file, AOL_FILEMODE);
     }
 
-    return 0;
+    return OL_SUCCESS;
 
 error:
-    return 1;
+    return OL_FAILURE;
 }
 
 vector *ol_bulk_unjar(ol_database *db, const ol_key_array keys, const size_t num_keys) {

--- a/src/test.c
+++ b/src/test.c
@@ -1014,6 +1014,23 @@ error:
     return 9;
 }
 
+int test_error_is_safe(const ol_feature_flags features) {
+    ol_database *db = _test_db_open(features);
+
+    db->meta->last_error = -1;
+    check(ol_last_error(db) == NULL, "Got something weird.");
+
+    db->meta->last_error = 666;
+    check(ol_last_error(db) == NULL, "Got something weird.");
+
+    _test_db_close(db);
+    return 0;
+
+error:
+    _test_db_close(db);
+    return 1;
+}
+
 int test_error_msg(const ol_feature_flags features) {
     ol_database *db = _test_db_open(features);
 
@@ -1147,6 +1164,7 @@ void run_tests(int results[2]) {
         const ol_feature_flags feature_set = (i | OL_F_AOL_FFLUSH) & OL_F_APPENDONLY;
         /* Fucking macros man */
         ol_run_test(test_error_msg);
+        ol_run_test(test_error_is_safe);
         ol_run_test(test_jar);
         ol_run_test(test_cas);
         ol_run_test(test_unjar);

--- a/src/test.c
+++ b/src/test.c
@@ -1014,6 +1014,19 @@ error:
     return 9;
 }
 
+int test_error_msg(const ol_feature_flags features) {
+    ol_database *db = _test_db_open(features);
+
+    check(strcmp(ol_last_error(db), "No error.") == 0, "Got wrong error message.");
+
+    _test_db_close(db);
+    return 0;
+
+error:
+    _test_db_close(db);
+    return 1;
+}
+
 int test_can_match_prefixes(const ol_feature_flags features) {
     ol_database *db = _test_db_open(features);
     int next_records = 10;
@@ -1133,6 +1146,7 @@ void run_tests(int results[2]) {
         /* OL_F_AOL_FFLUSH is slow as balls and we don't care about it */
         const ol_feature_flags feature_set = (i | OL_F_AOL_FFLUSH) & OL_F_APPENDONLY;
         /* Fucking macros man */
+        ol_run_test(test_error_msg);
         ol_run_test(test_jar);
         ol_run_test(test_cas);
         ol_run_test(test_unjar);

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -192,13 +192,13 @@ int olt_unjar(ol_transaction *tx, const char *key, size_t klen, unsigned char **
         if (!_has_bucket_expired(bucket)) {
             /* We don't need to fill out the data so just return 'we found the key'. */
             if (data == NULL)
-                return 0;
+                return OL_SUCCESS;
 
             const int ret = _ol_get_value_from_bucket(operating_db, bucket, data, dsize);
             check(ret == 0, "Could not retrieve value from bucket.");
 
             /* Key found, tell somebody. */
-            return 0;
+            return OL_SUCCESS;
         } else {
             /* It's dead, get rid of it. */
             /* NOTE: We explicitly say the transaction_db here because ITS A
@@ -207,10 +207,12 @@ int olt_unjar(ol_transaction *tx, const char *key, size_t klen, unsigned char **
         }
     }
 
-    return 1;
+    /* TODO: Set error code here (could not find key) */
+    return OL_FAILURE;
 
 error:
-    return 2;
+    /* TODO: Set error code here (generic error? Theres a couple failure modes here.)*/
+    return OL_FAILURE;
 }
 
 int olt_exists(ol_transaction *tx, const char *key, size_t klen) {

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -501,11 +501,11 @@ int olt_spoil(ol_transaction *tx, const char *key, size_t klen, struct tm *expir
         /* Flag the transaction as dirty. */
         tx->dirty = 1;
 
-        return 0;
+        return OL_SUCCESS;
     }
 
-    return 1;
+    return OL_FAILURE;
 
 error:
-    return 1;
+    return OL_FAILURE;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -118,7 +118,7 @@ int _ol_reallocate_bucket(ol_database *db, ol_bucket *bucket,
         if (db->state != OL_S_STARTUP) {
             /* Like above, avoid writing to the values file on startup. */
             if (memcpy(new_data_ptr, value, vsize) != new_data_ptr)
-                return 4;
+                return OL_FAILURE;
         }
     }
 
@@ -145,7 +145,7 @@ int _ol_reallocate_bucket(ol_database *db, ol_bucket *bucket,
         ol_aol_write_cmd(db, "JAR", bucket);
     }
 
-    return 0;
+    return OL_SUCCESS;
 }
 
 int _ol_set_bucket_no_incr(ol_database *db, ol_bucket *bucket, uint32_t hash) {


### PR DESCRIPTION
Unifies the way error codes are returned from `ol_*` and `olt_*` functions. No more of this kooky `int jar_ret = 10` stuff that I wrote. It's much clearer now from the code what to expect through various code paths.